### PR TITLE
Add CTS v4.00 XML validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # transport-document-validator
+
+This project demonstrates a minimal Spring Boot application using Java 21.
+
+## CTS validator
+
+A simple validator for CTS version 4.00 is provided. The validator checks an XML document against the `cts_400.xsd` schema located in `src/main/resources/xsd`.
+
+Run tests with Maven:
+
+```bash
+./mvnw test
+```
+

--- a/src/main/java/com/example/demo/service/CTSValidator.java
+++ b/src/main/java/com/example/demo/service/CTSValidator.java
@@ -1,0 +1,35 @@
+package com.example.demo.service;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+
+import org.xml.sax.SAXException;
+
+public class CTSValidator {
+
+    private final Validator validator;
+
+    public CTSValidator() {
+        try {
+            SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            InputStream xsdStream = getClass().getClassLoader().getResourceAsStream("xsd/cts_400.xsd");
+            Schema schema = factory.newSchema(new StreamSource(xsdStream));
+            this.validator = schema.newValidator();
+        } catch (SAXException e) {
+            throw new RuntimeException("Failed to load CTS schema", e);
+        }
+    }
+
+    public void validate(String xml) throws Exception {
+        try (InputStream xmlStream = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))) {
+            validator.validate(new StreamSource(xmlStream));
+        }
+    }
+}

--- a/src/main/resources/xsd/cts_400.xsd
+++ b/src/main/resources/xsd/cts_400.xsd
@@ -1,0 +1,15 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+  <xs:element name="CTS">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="id" type="xs:string"/>
+        <xs:element name="issueDate" type="xs:date"/>
+        <xs:element name="sender" type="xs:string"/>
+        <xs:element name="recipient" type="xs:string"/>
+      </xs:sequence>
+      <xs:attribute name="versao" type="xs:string" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/test/java/com/example/demo/CTSValidatorTest.java
+++ b/src/test/java/com/example/demo/CTSValidatorTest.java
@@ -1,0 +1,44 @@
+package com.example.demo;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.example.demo.service.CTSValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CTSValidatorTest {
+
+    private CTSValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new CTSValidator();
+    }
+
+    @Test
+    void validXmlShouldPass() {
+        String xml = """
+            <CTS versao=\"4.00\">
+                <id>123</id>
+                <issueDate>2024-01-01</issueDate>
+                <sender>Company A</sender>
+                <recipient>Company B</recipient>
+            </CTS>
+            """;
+        assertDoesNotThrow(() -> validator.validate(xml));
+    }
+
+    @Test
+    void invalidXmlShouldThrow() {
+        String xml = """
+            <CTS versao=\"4.00\">
+                <id>123</id>
+                <!-- missing issueDate -->
+                <sender>Company A</sender>
+                <recipient>Company B</recipient>
+            </CTS>
+            """;
+        assertThrows(Exception.class, () -> validator.validate(xml));
+    }
+}


### PR DESCRIPTION
## Summary
- implement simple CTS XML validator and tests
- add XSD schema for CTS 4.00
- document validator usage in README

## Testing
- `./mvnw test` *(fails: Maven could not be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_6865c2486efc8321945d1025077ff028